### PR TITLE
Issue #185 - neue Button-Variation luxStroked eingeführt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 11.14.0
+## New
+- **buttons**: Die Button-Variante luxStroked wurde eingeführt
+- **Theme - "green**: Bei den Buttons wurden Hover und Disabled gemäß den OZG-Vorgaben überarbeitet. LuxLink (raised=false) wurde dem Text-Link gemäß den OZG-Vorgaben angepasst. [Issue 185](https://github.com/IHK-GfI/lux-components/issues/185)
+
 # Version 11.13.0
 ## New
 - **chips**: Vorschlagsliste soll so breit wie die Chips-Komponente sein. [Issue 20](https://github.com/IHK-GfI/lux-components-theme/issues/20)

--- a/src/base/_luxcomponents.scss
+++ b/src/base/_luxcomponents.scss
@@ -1130,8 +1130,7 @@ lux-stepper-large {
   }
 
   &:not(.lux-touched) {
-    opacity: 0.6;
-    color: #003366;
+    color: $lux-stepper-large-nav-item-disabled-fg;
 
     .lux-stepper-large-nav-item-number-container {
       color: $lux-stepper-large-nav-item-disabled-fg;
@@ -1140,8 +1139,6 @@ lux-stepper-large {
   }
 
   &.lux-disabled {
-    opacity: 0.6;
-
     .lux-stepper-large-nav-item-number-container {
       color: $lux-stepper-large-nav-item-disabled-fg;
       background-color: $lux-stepper-large-nav-item-disabled-bg;
@@ -1149,7 +1146,7 @@ lux-stepper-large {
 
     .lux-stepper-large-nav-item-label {
       color: $lux-stepper-large-nav-item-disabled-fg;
-    }
+    }  
   }
 
   .lux-stepper-large-nav-item-number-container {

--- a/src/blue/_luxcommon.scss
+++ b/src/blue/_luxcommon.scss
@@ -47,7 +47,7 @@ $lux-stepper-large-completed-fc: #2E8533;
 
 $lux-stepper-large-nav-item-active-fc: #ffffff;
 $lux-stepper-large-nav-item-active-bg: #003366;
-$lux-stepper-large-nav-item-disabled-fg: #003366;
+$lux-stepper-large-nav-item-disabled-fg: #859db6;
 $lux-stepper-large-nav-item-disabled-bg: #eff3f6;
 $lux-stepper-large-nav-item-completed-fg: #ffffff;
 $lux-stepper-large-nav-item-completed-bg: #2E8533;

--- a/src/green/_custom.scss
+++ b/src/green/_custom.scss
@@ -391,12 +391,6 @@ lux-link {
         color: #56bd66 !important;
         background-color: #fff !important;
       }
-      // &.mat-button-disabled{
-      //   color: $blueInactiv !important;
-      //   &:hover {
-      //     color: $blueInactiv !important;
-      //   }
-      // }
     }
   }
 }

--- a/src/green/_custom.scss
+++ b/src/green/_custom.scss
@@ -392,6 +392,9 @@ lux-link {
         background-color: #fff !important;
       }
     }
+    &.mat-primary.mat-button-disabled {
+      color: $lux-stepper-large-nav-item-disabled-fg;
+    }
   }
 }
 

--- a/src/green/_custom.scss
+++ b/src/green/_custom.scss
@@ -276,9 +276,6 @@ lux-button button.lux-button {
       }
     }
   }
-  &.mat-raised-button.mat-accent:not(.mat-button-disabled), &.mat-fab.mat-accent:not(.mat-button-disabled) {
-    color: map-get($lux-palette-primary, 500);
-  }
 
   &.mat-button.mat-button-disabled,
   &.mat-raised-button.mat-button-disabled,
@@ -385,21 +382,21 @@ lux-button button.lux-button {
  * Theming für LUX-Link
  */
 lux-link {
-  lux-button.lux-link {
-    button.lux-button.mat-button:not(.mat-button-raised) {
+  button.lux-button.mat-button:not(.mat-button-raised) {
+    .lux-button-label {
       text-decoration: underline;
-      &.mat-primary {
-        &:hover {
-          color: #56bd66 !important;
-          background-color: #fff !important;
-        }
-        &.mat-button-disabled{
-          color: #b0c4d6 !important;
-          &:hover {
-            color: #b0c4d6 !important;
-          }
-        }
+    }
+    &.mat-primary:not(.mat-button-disabled) {
+      &:hover {
+        color: #56bd66 !important;
+        background-color: #fff !important;
       }
+      // &.mat-button-disabled{
+      //   color: $blueInactiv !important;
+      //   &:hover {
+      //     color: $blueInactiv !important;
+      //   }
+      // }
     }
   }
 }

--- a/src/green/_custom.scss
+++ b/src/green/_custom.scss
@@ -209,11 +209,18 @@ lux-app-header {
 /*
  * Theming for LUX-Button
  */
+ // Farbwerte gemäß OZG-Vorgaben
+ $blueHover: #335c85;
+ $blueInactiv: #b0c4d6;
+ $greenHover: #9ad7a3;
+ $greenInactiv: #e4F1e4;
+ $redHover: #f7767e;
+ $redInactiv: #ff9ca2; 
+
 lux-button button.lux-button {
+  font-weight: normal !important;
 
-  font-weight: lighter !important;
-
-  &.mat-button, &.mat-raised-button {
+  &.mat-button, &.mat-raised-button, &.mat-stroked-button {
     border-radius: 18px;
     height: $button-height;
     font-size: $button-font-size;
@@ -221,14 +228,129 @@ lux-button button.lux-button {
     margin-right: $outline-width;
   }
 
-  &.mat-button.mat-button-disabled,
-  &.mat-raised-button.mat-button-disabled,
-  &.mat-fab.mat-button-disabled {
-    color: $dark-disabled-text;
+  &.mat-button:not(.mat-button-disabled){
+    color: $dark-primary-text;
+    &:hover {
+      color: #fff !important;
+      background-color: $dark-secondary-text !important;   
+    }
+    &.mat-primary {
+      color: $lux-primary-color;
+      &:hover {
+        color: #fff !important;
+        background-color: $blueHover !important;
+      }
+    }
+    &.mat-accent {
+      color: $lux-accent-color;
+      &:hover {
+        color: map-get($lux-palette-primary, 500) !important;
+        background-color: $greenHover !important;
+      }
+    }
+    &.mat-warn {
+      color: $lux-warn-color;
+      &:hover {
+        color: #fff !important;
+        background-color: $redHover !important;
+      }
+    }
   }
-
+  
+  &.mat-raised-button:not(.mat-button-disabled),
+  &.mat-stroked-button:not(.mat-button-disabled),
+  &.mat-fab:not(.mat-button-disabled) {
+    &:hover{
+      color: #fff !important;
+      border: none !important;
+      background-color: $dark-secondary-text !important;   
+      &.mat-primary {
+        background-color: $blueHover !important;
+      }
+      &.mat-accent {
+        color: map-get($lux-palette-primary, 500) !important;
+        background-color: $greenHover !important;
+      }
+      &.mat-warn {
+        background-color: $redHover !important;
+      }
+    }
+  }
   &.mat-raised-button.mat-accent:not(.mat-button-disabled), &.mat-fab.mat-accent:not(.mat-button-disabled) {
     color: map-get($lux-palette-primary, 500);
+  }
+
+  &.mat-button.mat-button-disabled,
+  &.mat-raised-button.mat-button-disabled,
+  &.mat-stroked-button.mat-button-disabled,
+  &.mat-fab.mat-button-disabled {
+    &:hover {
+      cursor: not-allowed;
+    }
+  }
+  &.mat-button.mat-button-disabled {
+    color: $dark-disabled-text;
+    &.mat-primary {
+      color: $blueInactiv;
+    }
+    &.mat-accent {
+      color: $greenInactiv;
+    }
+    &.mat-warn {
+      color: $redInactiv;
+    }
+  }
+  &.mat-raised-button.mat-button-disabled, &.mat-fab.mat-button-disabled {
+    color: $dark-secondary-text;
+    background-color: $dark-disabled-text;
+    &.mat-primary {
+      color: #fff;
+      background-color: $blueInactiv;
+    }
+    &.mat-warn {
+      color: #fff;
+      background-color: $redInactiv;
+    }
+    &.mat-accent {
+      color: $blueHover;
+      background-color: $greenInactiv;
+    }
+  }
+  
+  &.mat-stroked-button {
+      color: $dark-primary-text;
+      border-color: $dark-primary-text;
+      &.mat-primary {
+        color: map-get($lux-palette-primary, 500);
+        border-color: map-get($lux-palette-primary, 500);
+      }
+      &.mat-accent {
+        color: map-get($lux-palette-accent, 500);
+        border-color: map-get($lux-palette-accent, 500);
+      }
+      &.mat-warn {
+        color: map-get($lux-palette_warn, 500);
+        border-color: map-get($lux-palette_warn, 500);
+      }
+    &.mat-button-disabled {
+      color: $dark-disabled-text;
+      border-color: $dark-disabled-text;
+      &.mat-primary {
+        color: $blueInactiv;
+        border-color: $blueInactiv;
+        background-color: unset;
+      }
+      &.mat-accent {
+        color: $greenInactiv;
+        border-color: $greenInactiv;
+        background-color: unset;
+      }
+      &.mat-warn {
+        color: $redInactiv;
+        border-color: $redInactiv;
+        background-color: unset;
+      }
+    }
   }
 
   &.lux-icon-button {
@@ -254,6 +376,29 @@ lux-button button.lux-button {
       i,
       mat-icon {
         font-size: 1.5em;
+      }
+    }
+  }
+}
+
+/**
+ * Theming für LUX-Link
+ */
+lux-link {
+  lux-button.lux-link {
+    button.lux-button.mat-button:not(.mat-button-raised) {
+      text-decoration: underline;
+      &.mat-primary {
+        &:hover {
+          color: #56bd66 !important;
+          background-color: #fff !important;
+        }
+        &.mat-button-disabled{
+          color: #b0c4d6 !important;
+          &:hover {
+            color: #b0c4d6 !important;
+          }
+        }
       }
     }
   }

--- a/src/green/_luxcommon.scss
+++ b/src/green/_luxcommon.scss
@@ -47,7 +47,7 @@ $lux-stepper-large-completed-fc: #2E8533;
 
 $lux-stepper-large-nav-item-active-fc: #ffffff;
 $lux-stepper-large-nav-item-active-bg: #003366;
-$lux-stepper-large-nav-item-disabled-fg: #003366;
+$lux-stepper-large-nav-item-disabled-fg: #859db6;
 $lux-stepper-large-nav-item-disabled-bg: #eff3f6;
 $lux-stepper-large-nav-item-completed-fg: #ffffff;
 $lux-stepper-large-nav-item-completed-bg: #2E8533;


### PR DESCRIPTION
Lux-Button hat die Variante luxStroked erhalten
Für das Green-Theme mussten die Stylevorgaben abweichend vom Material-Design  für diese Buttons ergänzt werden.
Zusätzlich wurden alle Hover und Disabled-Styles für die Buttons im Green-Theme überarbeitet.
normal für luxPrimary:
![image](https://user-images.githubusercontent.com/49644099/161540542-77bb51b9-783d-4681-b1aa-6f27a99c31bb.png)

Hover für luxPrimary:
![image](https://user-images.githubusercontent.com/49644099/161540361-d213a27c-76a8-4f56-9169-789b72fad2c0.png)

neue Disabled-Farben für die Buttons:
![image](https://user-images.githubusercontent.com/49644099/161540720-36a29e58-f33e-4535-a245-31ab9e6d81e2.png)

Der lux-link (color=primary, luxRaised=false) wurde gemäß der Vorgabe für Text-Links überarbeitet.
 
![image](https://user-images.githubusercontent.com/49644099/161540825-7eba1b16-41b9-46ec-9809-d71256d042d6.png)

und hover:
![image](https://user-images.githubusercontent.com/49644099/161540939-a6bd9e47-f9a0-45d2-bdd3-2fa4cebc937a.png)
