### PR TITLE
Issue #271: Auswahlbox bei lux-select-ac bei Theme authentic ungünsti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## New
 - **lux-app-header-ac**: Icon-Buttons im Header wurden neu zentriert [Issue 32](https://github.com/IHK-GfI/lux-components-theme/issues/32), Styleanpassungen für das neue Appicon und Brandlogo. [Issue 269](https://github.com/IHK-GfI/lux-components/issues/269)
 
+## Bug Fixes
+- **lux-select-ac**, **lux-lookup-combobox-ac**: Auswahlbox bei lux-select-ac im Theme authentic ungünstig positioniert. [Issue 271](https://github.com/IHK-GfI/lux-components/issues/271)
+
 # Version 14.1.0
 ## New
 - **allgemein**: Verbesserungen fürs Authentic-Themes.

--- a/src/base/components/_luxFormControlsAuthentic.scss
+++ b/src/base/components/_luxFormControlsAuthentic.scss
@@ -11,15 +11,6 @@
  */
  lux-select-ac, lux-lookup-combobox-ac {
   
-  & .lux-panel-opened {
-    //duch das Verschieben des Panels, verdeckt ein Teil der Overlay-Pane das Selectfeld 
-    // dieses ist damit als Trigger zum Schließen des Panels nicht mehr erreichbar
-    // daher wird temporär der z-index erhöht
-    .lux-form-control-container-authentic {
-      z-index: 10000;
-    }
-  }
-  
   mat-select {
     font-family: luxcommon.$app-font-family;
     height: calc( 1.5em - 1px) !important;
@@ -70,9 +61,6 @@
   .mat-autocomplete-panel.lux-autocomplete-panel-ac,
   .mat-select-panel.lux-select-panel-ac,
   .mat-select-panel.lux-select-panel-ac-multiple {
-    min-width: calc(100% + 14px) !important;
-    max-width: calc(100% + 14px) !important;
-    margin: 34px 7px;
     border: 2px solid luxpalette.$lux-primary-color;
     border-radius: 4px;
     box-shadow: none !important;
@@ -80,9 +68,6 @@
     .mat-pseudo-checkbox {
       color: luxpalette.$lux-primary-color;
     }
-  }
-  .mat-select-panel.lux-select-panel-ac-multiple {
-    margin: 34px 31px;
   }
 
   .mat-autocomplete-panel.lux-autocomplete-panel-ac {


### PR DESCRIPTION
…g positioniert

- die Positionierung unterhalb des form-control-containers wurde zurückgenommen
- die neue Berechnung der Breite wurde zurückgenommen.
- ab einer Min-width von 360px wird das geöffnete Panel vollständig angezeigt.
- ein Redesign ist für v15.0.0 geplant