### PR TITLE
Issue #349: Selected-Nav-Item im lux-app-header neu positioniert:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 15.1.0
+
+## Bug Fixes
+
+-**lux-app-header-ac**: Das Selected-Nav-Item wurde neue Positioniert. [Issue 349](https://github.com/IHK-GfI/lux-components/issues/349)
+
 # Version 15.0.0
 
 ## New

--- a/src/base/components/_luxAppHeaderAc.scss
+++ b/src/base/components/_luxAppHeaderAc.scss
@@ -141,6 +141,7 @@ lux-app-header-ac {
 
         &.nav-item-selected button.lux-button .lux-button-label {
           font-weight: 600;
+          height: 33px !important; //Sonst verschiebt sich die Höhe des Labels!
         }
       }
 


### PR DESCRIPTION
- die Höhe des labels wurde angepasst.